### PR TITLE
Fix GROUP BY statement

### DIFF
--- a/solutions/5.sql
+++ b/solutions/5.sql
@@ -1,5 +1,5 @@
 SELECT bands.name AS 'Band Name'
 FROM bands
 LEFT JOIN albums ON bands.id = albums.band_id
-GROUP BY albums.band_id
+GROUP BY bands.name
 HAVING COUNT(albums.id) = 0;


### PR DESCRIPTION
Original `GROUP BY albums.band_id` results in  `ERROR: column "bands.name" must appear in the GROUP BY clause or be used in an aggregate function` error.